### PR TITLE
#166187869 :Pagination support for articles

### DIFF
--- a/authors/apps/articles/pagination.py
+++ b/authors/apps/articles/pagination.py
@@ -1,0 +1,8 @@
+from rest_framework.pagination import LimitOffsetPagination
+
+
+class ArticleSetPagination(LimitOffsetPagination):
+    """set the number of articles to return on each page """
+    default_limit = 10
+    offset_query_param = 'offset'
+ 

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -9,13 +9,17 @@ from authors.apps.authentication.models import User
 from rest_framework.response import Response
 from drf_yasg.utils import swagger_auto_schema
 from django.shortcuts import get_object_or_404,get_list_or_404
-import json
-from rest_framework.exceptions import PermissionDenied 
+import json 
 from django.core.exceptions import ObjectDoesNotExist
+from rest_framework.exceptions import PermissionDenied
+from .pagination import ArticleSetPagination
+
+
 class ArticleView(ListCreateAPIView):
+    queryset = Article.objects.all()
     serializer_class = ArticleSerializer
     permission_classes = (IsAuthenticatedOrReadOnly,)
-    queryset = Article.objects.all()
+    pagination_class = ArticleSetPagination
 
     def post(self, request):
         article = request.data.get("article", {})
@@ -25,8 +29,10 @@ class ArticleView(ListCreateAPIView):
         serializer.save(
             author=User.objects.filter(username=request.user.username).first()
         )
-        response = {"success": "Article successfully created!",
-                    "data": serializer.data}
+        response = {
+            "success": "Article successfully created!", 
+            "data": serializer.data
+            }
         return Response(response, status=status.HTTP_201_CREATED)
 
 
@@ -91,6 +97,7 @@ class ArticleRetrieveUpdateDestroy(RetrieveUpdateDestroyAPIView):
             "status": status.HTTP_400_BAD_REQUEST
         }, status.HTTP_400_BAD_REQUEST)
 
+
     def delete(self, request, **kwargs):
         is_authenticated(request)
         article = Article.objects.filter(slug=kwargs.get('slug')).first()
@@ -106,7 +113,12 @@ class ArticleRetrieveUpdateDestroy(RetrieveUpdateDestroyAPIView):
         article.delete()
         response = {"success": "Article successfully deleted!",
                     "article": serializer.data}
+        response = {
+            "success": "Article successfully deleted!", 
+            "article": serializer.data
+            }
         return Response(response, status.HTTP_200_OK)
+
 
 def is_authenticated(request):
     user = request.user.id


### PR DESCRIPTION
 #### What this PR does?
- Support Pagination for articles
### Description of the task?
- user should be able to get articles on different pages
#### How can this manually be tested?
- Run `git fetch origin ft-Pagination-166187869`
- Run `python manage.py runserver`
- Now test out the following
- when there are already created articles
- Run `http://127.0.0.1:8000/api/articles/` and you will click on the link that has a ''next'' and "previous" to get the articles
<img width="882" alt="Screenshot 2019-06-19 at 2 38 08 PM" src="https://user-images.githubusercontent.com/43774983/59762411-e28f2c80-929f-11e9-9c0d-2c91d01750b9.png">

- Then you will send it again, there you will be able to get the articles and each page contains 10 article.

#### What are the relevant pivotal tracker stories
 [Finishes #166187869]